### PR TITLE
Create flywheel and agitator subsystems in shooter

### DIFF
--- a/ut-robomaster/src/robots/standard/robot_comms.cpp
+++ b/ut-robomaster/src/robots/standard/robot_comms.cpp
@@ -1,0 +1,34 @@
+#include "robot_comms.hpp"
+#include "tap/drivers.hpp"
+
+namespace comms {
+    
+RobotComms* RobotCommsSingleton::instance_ = nullptr;
+
+void RobotComms::terminalSerialStreamCallback(modm::IOStream& outputStream) {
+    outputStream << robotStream << modm::endl;
+    outputStream.flush();
+    outputStream << "hello" << modm::endl;
+    memset(robotStream, 0, sizeof(robotStream));
+}
+
+void RobotComms::init() {
+    drivers_->terminalSerial.addHeader(HEADER, this);
+}
+
+
+bool RobotComms::terminalSerialCallback(
+    char* inputLine,
+    modm::IOStream& outputStream,
+    bool streamingEnabled) 
+{
+   // remove everything from robotStream and write to outputStream
+    outputStream << robotStream << modm::endl;
+    outputStream.flush();
+    outputStream << "hello" << modm::endl;
+    memset(robotStream, 0, sizeof(robotStream));
+    streamingEnabled = true;
+    return true;
+}
+
+}

--- a/ut-robomaster/src/robots/standard/robot_comms.cpp
+++ b/ut-robomaster/src/robots/standard/robot_comms.cpp
@@ -1,34 +1,36 @@
 #include "robot_comms.hpp"
+
 #include "tap/drivers.hpp"
 
-namespace comms {
-    
+namespace comms
+{
+
 RobotComms* RobotCommsSingleton::instance_ = nullptr;
 
-void RobotComms::terminalSerialStreamCallback(modm::IOStream& outputStream) {
+void RobotComms::terminalSerialStreamCallback(modm::IOStream& outputStream)
+{
     outputStream << robotStream << modm::endl;
     outputStream.flush();
     outputStream << "hello" << modm::endl;
     memset(robotStream, 0, sizeof(robotStream));
+    robotStreamIndex = 0;
 }
 
-void RobotComms::init() {
-    drivers_->terminalSerial.addHeader(HEADER, this);
-}
-
+void RobotComms::init() { drivers_->terminalSerial.addHeader(HEADER, this); }
 
 bool RobotComms::terminalSerialCallback(
     char* inputLine,
     modm::IOStream& outputStream,
-    bool streamingEnabled) 
+    bool streamingEnabled)
 {
-   // remove everything from robotStream and write to outputStream
+    // remove everything from robotStream and write to outputStream
     outputStream << robotStream << modm::endl;
     outputStream.flush();
     outputStream << "hello" << modm::endl;
     memset(robotStream, 0, sizeof(robotStream));
+    robotStreamIndex = 0;
     streamingEnabled = true;
     return true;
 }
 
-}
+}  // namespace comms

--- a/ut-robomaster/src/robots/standard/robot_comms.cpp
+++ b/ut-robomaster/src/robots/standard/robot_comms.cpp
@@ -5,7 +5,7 @@
 namespace comms
 {
 
-RobotComms* RobotCommsSingleton::instance_ = nullptr;
+RobotComms RobotCommsSingleton::instance_;
 
 void RobotComms::terminalSerialStreamCallback(modm::IOStream& outputStream)
 {
@@ -16,7 +16,7 @@ void RobotComms::terminalSerialStreamCallback(modm::IOStream& outputStream)
     robotStreamIndex = 0;
 }
 
-void RobotComms::init() { drivers_->terminalSerial.addHeader(HEADER, this); }
+void RobotComms::init(tap::Drivers* drivers) { drivers->terminalSerial.addHeader(HEADER, this); }
 
 bool RobotComms::terminalSerialCallback(
     char* inputLine,

--- a/ut-robomaster/src/robots/standard/robot_comms.hpp
+++ b/ut-robomaster/src/robots/standard/robot_comms.hpp
@@ -1,15 +1,15 @@
 #include "tap/communication/serial/terminal_serial.hpp"
 
-namespace comms {
+namespace comms
+{
 
-class RobotComms : public tap::communication::serial::TerminalSerialCallbackInterface {
-// make this a singleton
+class RobotComms : public tap::communication::serial::TerminalSerialCallbackInterface
+{
+    // make this a singleton
 public:
     static constexpr char HEADER[] = "startcomm";
-    
-    RobotComms(tap::Drivers *drivers) : drivers_(drivers) {
 
-    }
+    RobotComms(tap::Drivers* drivers) : drivers_(drivers) {}
     mockable void init();
 
     bool terminalSerialCallback(
@@ -20,26 +20,38 @@ public:
     void terminalSerialStreamCallback(modm::IOStream& outputStream) override;
 
     // robot writes to this stream, and this stream is written to TerminalSerial's stream
-    char robotStream[100];
-    
+    char robotStream[1000];
+    uint32_t robotStreamIndex = 0;
 
 private:
-    tap::Drivers *drivers_;
+    tap::Drivers* drivers_;
 };
 
-class RobotCommsSingleton {
+class RobotCommsSingleton
+{
 public:
     static RobotComms* instance_;
 
-    static void init(tap::Drivers *drivers) {
+    static void init(tap::Drivers* drivers)
+    {
         instance_ = new RobotComms(drivers);
         instance_->init();
     }
 
-    static RobotComms& getInstance() {
-        return *instance_;
-    }
+    static RobotComms& getInstance() { return *instance_; }
 
+    static void print(const char* format, ...)
+    {
+        // concatenate the string to robotStream
+        va_list args;
+        va_start(args, format);
+        instance_->robotStreamIndex += vsnprintf(
+            instance_->robotStream + instance_->robotStreamIndex,
+            sizeof(instance_->robotStream) - instance_->robotStreamIndex,
+            format,
+            args);
+        va_end(args);
+    }
 };
 
 }  // namespace comms

--- a/ut-robomaster/src/robots/standard/robot_comms.hpp
+++ b/ut-robomaster/src/robots/standard/robot_comms.hpp
@@ -1,0 +1,45 @@
+#include "tap/communication/serial/terminal_serial.hpp"
+
+namespace comms {
+
+class RobotComms : public tap::communication::serial::TerminalSerialCallbackInterface {
+// make this a singleton
+public:
+    static constexpr char HEADER[] = "startcomm";
+    
+    RobotComms(tap::Drivers *drivers) : drivers_(drivers) {
+
+    }
+    mockable void init();
+
+    bool terminalSerialCallback(
+        char* inputLine,
+        modm::IOStream& outputStream,
+        bool streamingEnabled) override;
+
+    void terminalSerialStreamCallback(modm::IOStream& outputStream) override;
+
+    // robot writes to this stream, and this stream is written to TerminalSerial's stream
+    char robotStream[100];
+    
+
+private:
+    tap::Drivers *drivers_;
+};
+
+class RobotCommsSingleton {
+public:
+    static RobotComms* instance_;
+
+    static void init(tap::Drivers *drivers) {
+        instance_ = new RobotComms(drivers);
+        instance_->init();
+    }
+
+    static RobotComms& getInstance() {
+        return *instance_;
+    }
+
+};
+
+}  // namespace comms

--- a/ut-robomaster/src/robots/standard/standard_control.cpp
+++ b/ut-robomaster/src/robots/standard/standard_control.cpp
@@ -95,6 +95,7 @@ void registerStandardSubsystems(tap::Drivers *drivers)
 {
     // drivers->commandScheduler.registerSubsystem(&theAgitator);
     drivers->commandScheduler.registerSubsystem(&theShooter);
+    theShooter.registerSubsystems();
     // drivers->commandScheduler.registerSubsystem(&theChassis);
     // drivers->commandScheduler.registerSubsystem(&theTurret);    // mouse
     //drivers->commandScheduler.registerSubsystem(&theGimbal);     // joystick

--- a/ut-robomaster/src/robots/standard/standard_control.cpp
+++ b/ut-robomaster/src/robots/standard/standard_control.cpp
@@ -83,17 +83,17 @@ HoldRepeatCommandMapping leftSwitchUp(
     true,
     -1);
 
-HoldRepeatCommandMapping rightMouseDown(
+HoldRepeatCommandMapping leftMouseDown(
     drivers(),
     {&shooterCommand},
-    RemoteMapState(RemoteMapState::MouseButton::RIGHT),
+    RemoteMapState(RemoteMapState::MouseButton::LEFT),
     true,
     -1);
 
 PressCommandMapping singleFire(
     drivers(),
     {&singleFireCommand},
-    RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
+    RemoteMapState(tap::control::RemoteMapState::MouseButton::RIGHT));
 
 // HoldRepeatCommandMapping leftMouseDown(
 //     drivers(),
@@ -141,8 +141,8 @@ void registerStandardIoMappings(tap::Drivers *drivers)
     // drivers->commandMapper.addMap(&rightSwitchDown);
     drivers->commandMapper.addMap(&leftSwitchUp);
     drivers->commandMapper.addMap(&singleFire);
-    // drivers->commandMapper.addMap(&leftMouseDown);
-    drivers->commandMapper.addMap(&rightMouseDown);
+    drivers->commandMapper.addMap(&leftMouseDown);
+    // drivers->commandMapper.addMap(&rightMouseDown);
 }
 }  // namespace standard_control
 

--- a/ut-robomaster/src/robots/standard/standard_control.cpp
+++ b/ut-robomaster/src/robots/standard/standard_control.cpp
@@ -10,7 +10,7 @@
 #include "tap/control/hold_command_mapping.hpp"
 #include "tap/control/press_command_mapping.hpp"
 #include "tap/drivers.hpp"
-
+#include "robot_comms.hpp"
 
 
 // #include "agitator/agitator_rotate_command.hpp"
@@ -49,6 +49,7 @@ namespace standard_control
 {
 /* define subsystems --------------------------------------------------------*/
 // control::agitator::AgitatorSubsystem theAgitator(drivers());
+comms::RobotComms theRobotComms(drivers());
 subsystems::shooter::ShooterSubsystem theShooter(drivers());
 // control::turret::TurretSubsystem theTurret(drivers());  // mouse  
 // control::gimbal::GimbalSubsystem theGimbal(drivers());   // joystick
@@ -146,11 +147,16 @@ namespace control
 {
     void initSubsystemCommands(tap::Drivers *drivers)
     {
+        comms::RobotCommsSingleton::init(drivers);
+
         standard_control::initializeSubsystems();
         standard_control::registerStandardSubsystems(drivers);
         standard_control::setDefaultStandardCommands(drivers);
         standard_control::startStandardCommands(drivers);
         standard_control::registerStandardIoMappings(drivers);
+
+
+        
     }
 }
 

--- a/ut-robomaster/src/robots/standard/standard_control.cpp
+++ b/ut-robomaster/src/robots/standard/standard_control.cpp
@@ -18,6 +18,7 @@
 // #include "agitator/agitator_subsystem.hpp"
 
 #include "subsystems/shooter/shooter_on_command.hpp"
+#include "subsystems/shooter/shooter_single_fire_command.hpp"
 #include "subsystems/shooter/shooter_subsystem.hpp"
 
 // #include "chassis/chassis_subsystem.hpp"
@@ -57,6 +58,7 @@ subsystems::shooter::ShooterSubsystem theShooter(drivers());
 // control::agitator::AgitatorRotateCommand rotateCommand(&theAgitator);
 // control::agitator::AgitatorReverseCommand reverseCommand(&theAgitator);
 subsystems::shooter::ShooterOnCommand shooterCommand(&theShooter);
+subsystems::shooter::ShooterSingleFireCommand singleFireCommand(&theShooter);
 // control::chassis::ChassisDriveKeyboardCommand chassisDriveKeyboardCommand(drivers(), &theChassis);  // keyboard
 //control::chassis::ChassisDriveCommand chassisDriveCommand(drivers(), &theChassis);   // joystick
 // control::turret::TurretMoveCommand turretMoveCommand(drivers(), &theTurret);    //mouse 
@@ -82,6 +84,11 @@ HoldRepeatCommandMapping rightMouseDown(
     drivers(),
     {&shooterCommand},
     RemoteMapState(RemoteMapState::MouseButton::RIGHT), true, -1);
+
+PressCommandMapping singleFire(
+    drivers(),
+    {&singleFireCommand},
+    RemoteMapState(Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP));
 
 // HoldRepeatCommandMapping leftMouseDown(
 //     drivers(),
@@ -129,6 +136,7 @@ void registerStandardIoMappings(tap::Drivers *drivers)
     // drivers->commandMapper.addMap(&reverseAgitator);
     // drivers->commandMapper.addMap(&rightSwitchDown);
     drivers->commandMapper.addMap(&leftSwitchUp);
+    drivers->commandMapper.addMap(&singleFire);
     // drivers->commandMapper.addMap(&leftMouseDown);
     drivers->commandMapper.addMap(&rightMouseDown);
 }

--- a/ut-robomaster/src/robots/standard/standard_control.cpp
+++ b/ut-robomaster/src/robots/standard/standard_control.cpp
@@ -2,16 +2,16 @@
 
 // #ifdef TARGET_STANDARD
 
+#include "tap/control/command_mapper.hpp"
+#include "tap/control/hold_command_mapping.hpp"
+#include "tap/control/hold_repeat_command_mapping.hpp"
+#include "tap/control/press_command_mapping.hpp"
+#include "tap/control/toggle_command_mapping.hpp"
+#include "tap/drivers.hpp"
+
 #include "drivers.hpp"
 #include "drivers_singleton.hpp"
-
-#include "tap/control/command_mapper.hpp"
-#include "tap/control/hold_repeat_command_mapping.hpp"
-#include "tap/control/hold_command_mapping.hpp"
-#include "tap/control/press_command_mapping.hpp"
-#include "tap/drivers.hpp"
 #include "robot_comms.hpp"
-
 
 // #include "agitator/agitator_rotate_command.hpp"
 // #include "agitator/agitator_reverse_command.hpp"
@@ -51,7 +51,7 @@ namespace standard_control
 // control::agitator::AgitatorSubsystem theAgitator(drivers());
 comms::RobotComms theRobotComms(drivers());
 subsystems::shooter::ShooterSubsystem theShooter(drivers());
-// control::turret::TurretSubsystem theTurret(drivers());  // mouse  
+// control::turret::TurretSubsystem theTurret(drivers());  // mouse
 // control::gimbal::GimbalSubsystem theGimbal(drivers());   // joystick
 // control::chassis::ChassisSubsystem theChassis(drivers(), &theTurret.getYawMotor());
 
@@ -60,10 +60,11 @@ subsystems::shooter::ShooterSubsystem theShooter(drivers());
 // control::agitator::AgitatorReverseCommand reverseCommand(&theAgitator);
 subsystems::shooter::ShooterOnCommand shooterCommand(&theShooter);
 subsystems::shooter::ShooterSingleFireCommand singleFireCommand(&theShooter);
-// control::chassis::ChassisDriveKeyboardCommand chassisDriveKeyboardCommand(drivers(), &theChassis);  // keyboard
-//control::chassis::ChassisDriveCommand chassisDriveCommand(drivers(), &theChassis);   // joystick
-// control::turret::TurretMoveCommand turretMoveCommand(drivers(), &theTurret);    //mouse 
-//control::gimbal::GimbalMoveCommand gimbalMoveCommand(drivers(), &theGimbal);     //joystick
+// control::chassis::ChassisDriveKeyboardCommand chassisDriveKeyboardCommand(drivers(),
+// &theChassis);  // keyboard
+// control::chassis::ChassisDriveCommand chassisDriveCommand(drivers(), &theChassis);   // joystick
+// control::turret::TurretMoveCommand turretMoveCommand(drivers(), &theTurret);    //mouse
+// control::gimbal::GimbalMoveCommand gimbalMoveCommand(drivers(), &theGimbal);     //joystick
 
 /* define command mappings --------------------------------------------------*/
 // HoldRepeatCommandMapping reverseAgitator(
@@ -79,12 +80,16 @@ subsystems::shooter::ShooterSingleFireCommand singleFireCommand(&theShooter);
 HoldRepeatCommandMapping leftSwitchUp(
     drivers(),
     {&shooterCommand},
-    RemoteMapState(Remote::Switch::LEFT_SWITCH, Remote::SwitchState::UP), true, -1);
+    RemoteMapState(Remote::Switch::LEFT_SWITCH, Remote::SwitchState::UP),
+    true,
+    -1);
 
 HoldRepeatCommandMapping rightMouseDown(
     drivers(),
     {&shooterCommand},
-    RemoteMapState(RemoteMapState::MouseButton::RIGHT), true, -1);
+    RemoteMapState(RemoteMapState::MouseButton::RIGHT),
+    true,
+    -1);
 
 PressCommandMapping singleFire(
     drivers(),
@@ -96,8 +101,6 @@ PressCommandMapping singleFire(
 //     {&rotateCommand},
 //     RemoteMapState(RemoteMapState::MouseButton::LEFT), true, -1);
 
-
-
 /* register subsystems here -------------------------------------------------*/
 void registerStandardSubsystems(tap::Drivers *drivers)
 {
@@ -106,20 +109,21 @@ void registerStandardSubsystems(tap::Drivers *drivers)
     theShooter.registerSubsystems();
     // drivers->commandScheduler.registerSubsystem(&theChassis);
     // drivers->commandScheduler.registerSubsystem(&theTurret);    // mouse
-    //drivers->commandScheduler.registerSubsystem(&theGimbal);     // joystick
+    // drivers->commandScheduler.registerSubsystem(&theGimbal);     // joystick
 }
 
 /* initialize subsystems ----------------------------------------------------*/
-void initializeSubsystems() { 
+void initializeSubsystems()
+{
     // theAgitator.initialize();
     theShooter.initialize();
     // theChassis.initialize();
     // theTurret.initialize();     // mouse
-    //theGimbal.initialize();  // joystick
+    // theGimbal.initialize();  // joystick
 }
 
 /* set any default commands to subsystems here ------------------------------*/
-void setDefaultStandardCommands(tap::Drivers *) 
+void setDefaultStandardCommands(tap::Drivers *)
 {
     // theChassis.setDefaultCommand(&chassisDriveKeyboardCommand); // keyboard
     // theChassis.setDefaultCommand(&chassisDriveCommand);  //joystick
@@ -141,24 +145,21 @@ void registerStandardIoMappings(tap::Drivers *drivers)
     // drivers->commandMapper.addMap(&leftMouseDown);
     drivers->commandMapper.addMap(&rightMouseDown);
 }
-} // namespace standard_control
+}  // namespace standard_control
 
 namespace control
 {
-    void initSubsystemCommands(tap::Drivers *drivers)
-    {
-        comms::RobotCommsSingleton::init(drivers);
+void initSubsystemCommands(tap::Drivers *drivers)
+{
+    comms::RobotCommsSingleton::init(drivers);
 
-        standard_control::initializeSubsystems();
-        standard_control::registerStandardSubsystems(drivers);
-        standard_control::setDefaultStandardCommands(drivers);
-        standard_control::startStandardCommands(drivers);
-        standard_control::registerStandardIoMappings(drivers);
-
-
-        
-    }
+    standard_control::initializeSubsystems();
+    standard_control::registerStandardSubsystems(drivers);
+    standard_control::setDefaultStandardCommands(drivers);
+    standard_control::startStandardCommands(drivers);
+    standard_control::registerStandardIoMappings(drivers);
 }
+}  // namespace control
 
 // #endif
 // #endif

--- a/ut-robomaster/src/robots/standard/standard_control.cpp
+++ b/ut-robomaster/src/robots/standard/standard_control.cpp
@@ -49,7 +49,6 @@ namespace standard_control
 {
 /* define subsystems --------------------------------------------------------*/
 // control::agitator::AgitatorSubsystem theAgitator(drivers());
-comms::RobotComms theRobotComms(drivers());
 subsystems::shooter::ShooterSubsystem theShooter(drivers());
 // control::turret::TurretSubsystem theTurret(drivers());  // mouse
 // control::gimbal::GimbalSubsystem theGimbal(drivers());   // joystick

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -9,6 +9,7 @@ AgitatorSubsystem::AgitatorSubsystem(tap::Drivers *drivers, tap::motor::MotorId 
         canBusMotors(canBusMotors),
         motorOutput(0),
         pidController(0.5f, 0.0f, 0.0f, 5000.0f, MAX_CURRENT_OUTPUT),
+        targetAnglePidController(0.15f, 0.0001f, 0.01f, 5000.0f, MAX_CURRENT_OUTPUT / 4.0f), // TODO: Tune PID
         motor(
             drivers,
             motorId,
@@ -39,5 +40,12 @@ void AgitatorSubsystem::setMotorOutput(int desiredRPM)
         motor.setDesiredOutput(static_cast<int32_t>(pidController.getValue()));
     }
 }
+
+void AgitatorSubsystem::rotateToTarget(int64_t targetPosition)
+{
+    targetAnglePidController.update(targetPosition - motor.getEncoderUnwrapped());
+    motor.setDesiredOutput(static_cast<int32_t>(targetAnglePidController.getValue()));
+}
+
 
 }

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -45,24 +45,20 @@ void AgitatorSubsystem::setMotorOutput(int desiredRPM)
 void AgitatorSubsystem::rotateToTarget(int64_t targetPosition)
 {
     int64_t currentPosition = motor.getEncoderUnwrapped();
-
     
     float normalizedDifferenceAbsolute = std::min(std::abs(static_cast<int32_t>(targetPosition - currentPosition) / 2048.0f), 1.0f);
     int32_t signOfDifference = (targetPosition - currentPosition) / std::abs(targetPosition - currentPosition);
 
-    // normalizedDifferenceAbsolute -= 0.2f; 
-
-    // // theoretically, this will be a value between 0 and MAX_CURRENT_OUTPUT / 4.0f
-    // int32_t error = static_cast<int32_t>(  std::pow(normalizedDifferenceAbsolute, 2) * MAX_CURRENT_OUTPUT / 6.0f );
-
-     
     int32_t error = signOfDifference * normalizedDifferenceAbsolute * MAX_CURRENT_OUTPUT / 4.0f;
-    
-    // error += 256.0 * -1 * signOfDifference;
     
     targetAnglePidController.update(targetPosition - currentPosition);
     motor.setDesiredOutput(static_cast<int32_t>(targetAnglePidController.getValue()));
 }
 
+bool AgitatorSubsystem::isNearTarget(int64_t targetPosition)
+{
+    int64_t currentPosition = motor.getEncoderUnwrapped();
+    return std::abs(targetPosition - currentPosition) < NEAR_TARGET_THRESHOLD;
+}
 
 }

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -58,7 +58,7 @@ void AgitatorSubsystem::rotateToTarget(int64_t targetPosition)
     motor.setDesiredOutput(static_cast<int32_t>(targetAnglePidController.getValue()));
 
     // char* toSend = "Agitator: " + std::to_string(currentPosition) + " " + std::to_string(targetPosition) + " " + std::to_string(error);
-    sprintf(comms::RobotCommsSingleton::getInstance().robotStream, "Agitator: %lld %lld %ld", currentPosition, targetPosition, error);
+    comms::RobotCommsSingleton::print("Agitator: %lld %lld %ld", currentPosition, targetPosition, error);
 
     // strcpy(comms::RobotCommsSingleton::getInstance().robotStream, toSend);
 }

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -1,34 +1,36 @@
 #include "agitator_subsystem.hpp"
+
 #include <algorithm>
+
 #include "tap/drivers.hpp"
+
 #include "robots/standard/robot_comms.hpp"
 
 namespace subsystems::shooter
 {
 
-AgitatorSubsystem::AgitatorSubsystem(tap::Drivers *drivers, tap::motor::MotorId motorId, tap::can::CanBus canBusMotors)
-    :   Subsystem(drivers),
-        localDriversRef(drivers),
-        motorId(motorId),
-        canBusMotors(canBusMotors),
-        motorOutput(0),
-        pidController(22.0f, 0.5f, 0.0f, 5000.0f, MAX_CURRENT_OUTPUT),
-        targetAnglePidController(0.75f, 0.00f, 75.0f, 100000.0f, MAX_CURRENT_OUTPUT / 4), // TODO: Tune PID
-        motor(
-            drivers,
-            motorId,
-            canBusMotors,
-            true,
-            "agitator motor"
-        )
+AgitatorSubsystem::AgitatorSubsystem(
+    tap::Drivers *drivers,
+    tap::motor::MotorId motorId,
+    tap::can::CanBus canBusMotors)
+    : Subsystem(drivers),
+      localDriversRef(drivers),
+      motorId(motorId),
+      canBusMotors(canBusMotors),
+      motorOutput(0),
+      pidController(22.0f, 0.5f, 0.0f, 5000.0f, MAX_CURRENT_OUTPUT),
+      targetAnglePidController(
+          0.75f,
+          0.00f,
+          75.0f,
+          100000.0f,
+          MAX_CURRENT_OUTPUT / 4),  // TODO: Tune PID
+      motor(drivers, motorId, canBusMotors, true, "agitator motor")
 {
     setMotorOutput(0);
 }
 
-void AgitatorSubsystem::initialize()
-{
-    motor.initialize();
-}
+void AgitatorSubsystem::initialize() { motor.initialize(); }
 
 // void AgitatorSubsystem::refresh() {}
 
@@ -48,17 +50,24 @@ void AgitatorSubsystem::setMotorOutput(int desiredRPM)
 void AgitatorSubsystem::rotateToTarget(int64_t targetPosition)
 {
     int64_t currentPosition = motor.getEncoderUnwrapped();
-    
-    float normalizedDifferenceAbsolute = std::min(std::abs(static_cast<int32_t>(targetPosition - currentPosition) / 2048.0f), 1.0f);
-    int32_t signOfDifference = (targetPosition - currentPosition) / std::abs(targetPosition - currentPosition);
+
+    float normalizedDifferenceAbsolute =
+        std::min(std::abs(static_cast<int32_t>(targetPosition - currentPosition) / 2048.0f), 1.0f);
+    int32_t signOfDifference =
+        (targetPosition - currentPosition) / std::abs(targetPosition - currentPosition);
 
     int32_t error = signOfDifference * normalizedDifferenceAbsolute * MAX_CURRENT_OUTPUT / 4.0f;
-    
+
     targetAnglePidController.update(targetPosition - currentPosition);
     motor.setDesiredOutput(static_cast<int32_t>(targetAnglePidController.getValue()));
 
-    // char* toSend = "Agitator: " + std::to_string(currentPosition) + " " + std::to_string(targetPosition) + " " + std::to_string(error);
-    comms::RobotCommsSingleton::print("Agitator: %lld %lld %ld", currentPosition, targetPosition, error);
+    // char* toSend = "Agitator: " + std::to_string(currentPosition) + " " +
+    // std::to_string(targetPosition) + " " + std::to_string(error);
+    comms::RobotCommsSingleton::print(
+        "Agitator: %lld %lld %ld",
+        currentPosition,
+        targetPosition,
+        error);
 
     // strcpy(comms::RobotCommsSingleton::getInstance().robotStream, toSend);
 }
@@ -69,4 +78,4 @@ bool AgitatorSubsystem::isNearTarget(int64_t targetPosition)
     return std::abs(targetPosition - currentPosition) < NEAR_TARGET_THRESHOLD;
 }
 
-}
+}  // namespace subsystems::shooter

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -10,7 +10,7 @@ AgitatorSubsystem::AgitatorSubsystem(tap::Drivers *drivers, tap::motor::MotorId 
         canBusMotors(canBusMotors),
         motorOutput(0),
         pidController(22.0f, 0.5f, 0.0f, 5000.0f, MAX_CURRENT_OUTPUT),
-        targetAnglePidController(0.375f, 0.025f, 1.0f, 5000.0f, MAX_CURRENT_OUTPUT / 4.0f), // TODO: Tune PID
+        targetAnglePidController(0.75f, 0.00f, 75.0f, 100000.0f, MAX_CURRENT_OUTPUT / 4), // TODO: Tune PID
         motor(
             drivers,
             motorId,
@@ -60,7 +60,7 @@ void AgitatorSubsystem::rotateToTarget(int64_t targetPosition)
     
     // error += 256.0 * -1 * signOfDifference;
     
-    targetAnglePidController.update(error);
+    targetAnglePidController.update(targetPosition - currentPosition);
     motor.setDesiredOutput(static_cast<int32_t>(targetAnglePidController.getValue()));
 }
 

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -1,0 +1,43 @@
+#include "agitator_subsystem.hpp"
+
+namespace subsystems::shooter
+{
+
+AgitatorSubsystem::AgitatorSubsystem(tap::Drivers *drivers, tap::motor::MotorId motorId, tap::can::CanBus canBusMotors)
+    :   Subsystem(drivers),
+        motorId(motorId),
+        canBusMotors(canBusMotors),
+        motorOutput(0),
+        pidController(0.5f, 0.0f, 0.0f, 5000.0f, MAX_CURRENT_OUTPUT),
+        motor(
+            drivers,
+            motorId,
+            canBusMotors,
+            true,
+            "agitator motor"
+        )
+{
+    setMotorOutput(0);
+}
+
+void AgitatorSubsystem::initialize()
+{
+    motor.initialize();
+}
+
+// void AgitatorSubsystem::refresh() {}
+
+void AgitatorSubsystem::setMotorOutput(int desiredRPM)
+{
+    if (desiredRPM == 0)
+    {
+        motor.setDesiredOutput(0);
+    }
+    else
+    {
+        pidController.update(desiredRPM - motor.getShaftRPM());
+        motor.setDesiredOutput(static_cast<int32_t>(pidController.getValue()));
+    }
+}
+
+}

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.cpp
@@ -1,11 +1,14 @@
 #include "agitator_subsystem.hpp"
 #include <algorithm>
+#include "tap/drivers.hpp"
+#include "robots/standard/robot_comms.hpp"
 
 namespace subsystems::shooter
 {
 
 AgitatorSubsystem::AgitatorSubsystem(tap::Drivers *drivers, tap::motor::MotorId motorId, tap::can::CanBus canBusMotors)
     :   Subsystem(drivers),
+        localDriversRef(drivers),
         motorId(motorId),
         canBusMotors(canBusMotors),
         motorOutput(0),
@@ -53,6 +56,11 @@ void AgitatorSubsystem::rotateToTarget(int64_t targetPosition)
     
     targetAnglePidController.update(targetPosition - currentPosition);
     motor.setDesiredOutput(static_cast<int32_t>(targetAnglePidController.getValue()));
+
+    // char* toSend = "Agitator: " + std::to_string(currentPosition) + " " + std::to_string(targetPosition) + " " + std::to_string(error);
+    sprintf(comms::RobotCommsSingleton::getInstance().robotStream, "Agitator: %lld %lld %ld", currentPosition, targetPosition, error);
+
+    // strcpy(comms::RobotCommsSingleton::getInstance().robotStream, toSend);
 }
 
 bool AgitatorSubsystem::isNearTarget(int64_t targetPosition)

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
@@ -33,7 +33,7 @@ private:
     modm::Pid<float> targetAnglePidController;
     tap::motor::DjiMotor motor;
     static constexpr float MAX_CURRENT_OUTPUT = 8000.0f;
-    static constexpr int NEAR_TARGET_THRESHOLD = 282; // 1/10 of one ball's worth of encoder ticks
+    static constexpr int NEAR_TARGET_THRESHOLD = 900; // 1/10 of one ball's worth of encoder ticks
 };
 
 }

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
@@ -1,0 +1,39 @@
+#ifndef SUBSYSTEMS_SHOOTER_AGITATOR_SUBSYSTEM_HPP_
+#define SUBSYSTEMS_SHOOTER_AGITATOR_SUBSYSTEM_HPP_
+
+#include "modm/math/filter/pid.hpp"
+#include "tap/control/subsystem.hpp"
+#include "tap/motor/dji_motor.hpp"
+
+namespace subsystems
+{
+namespace shooter
+{
+
+// Agitator uses DJI motors
+class AgitatorSubsystem : public tap::control::Subsystem
+{
+public:
+    AgitatorSubsystem(tap::Drivers *drivers, tap::motor::MotorId motorId, tap::can::CanBus canBusMotors);
+    ~AgitatorSubsystem() = default;
+
+    void initialize() override;
+
+    void setMotorOutput(int desiredRPM);
+
+    // Default refresh for Subsystem is no-op
+    // void refresh() override;
+
+private:
+    const tap::motor::MotorId motorId;
+    const tap::can::CanBus canBusMotors;
+    uint16_t motorOutput; // Unused?
+    modm::Pid<float> pidController; // Should the PID controller use int instead? Check kp
+    tap::motor::DjiMotor motor;
+    static constexpr float MAX_CURRENT_OUTPUT = 8000.0f;
+};
+
+}
+}
+
+#endif // SUBSYSTEMS_SHOOTER_AGITATOR_SUBSYSTEM_HPP_

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
@@ -20,6 +20,7 @@ public:
     void initialize() override;
 
     void setMotorOutput(int desiredRPM);
+    void rotateToTarget(int64_t targetPosition);
 
     // Default refresh for Subsystem is no-op
     // void refresh() override;
@@ -29,6 +30,7 @@ private:
     const tap::can::CanBus canBusMotors;
     uint16_t motorOutput; // Unused?
     modm::Pid<float> pidController; // Should the PID controller use int instead? Check kp
+    modm::Pid<float> targetAnglePidController;
     tap::motor::DjiMotor motor;
     static constexpr float MAX_CURRENT_OUTPUT = 8000.0f;
 };

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
@@ -21,7 +21,7 @@ public:
 
     void setMotorOutput(int desiredRPM);
     void rotateToTarget(int64_t targetPosition);
-
+    bool isNearTarget(int64_t targetPosition);
     // Default refresh for Subsystem is no-op
     // void refresh() override;
 
@@ -33,6 +33,7 @@ private:
     modm::Pid<float> targetAnglePidController;
     tap::motor::DjiMotor motor;
     static constexpr float MAX_CURRENT_OUTPUT = 8000.0f;
+    static constexpr int NEAR_TARGET_THRESHOLD = 282; // 1/10 of one ball's worth of encoder ticks
 };
 
 }

--- a/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/agitator_subsystem.hpp
@@ -32,6 +32,7 @@ private:
     modm::Pid<float> pidController; // Should the PID controller use int instead? Check kp
     modm::Pid<float> targetAnglePidController;
     tap::motor::DjiMotor motor;
+    tap::Drivers *localDriversRef;
     static constexpr float MAX_CURRENT_OUTPUT = 8000.0f;
     static constexpr int NEAR_TARGET_THRESHOLD = 900; // 1/10 of one ball's worth of encoder ticks
 };

--- a/ut-robomaster/src/subsystems/shooter/flywheel_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/flywheel_subsystem.cpp
@@ -1,0 +1,94 @@
+#include "flywheel_subsystem.hpp"
+
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+#include "tap/drivers.hpp"
+#endif
+
+namespace subsystems::shooter
+{
+
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+FlywheelSubsystem::FlywheelSubsystem(tap::Drivers *drivers, tap::gpio::Pwm::Pin motorPin)
+    :   Subsystem(drivers),
+        motorPin(motorPin)
+{
+    setMotorOutput(0.0);
+}
+#else
+FlywheelSubsystem::FlywheelSubsystem(tap::Drivers *drivers, tap::motor::MotorId motorId, tap::can::CanBus canBusMotors)
+    :   Subsystem(drivers),
+        motorId(motorId),
+        canBusMotors(canBusMotors),
+        motorOutput(0),
+        pidController(0.5f, 0.0f, 0.0f, 5000.0f, MAX_CURRENT_OUTPUT),
+        motor(
+            drivers,
+            motorId,
+            canBusMotors,
+            true,
+            FlywheelSubsystem::getMotorName(motorId)
+        )
+{
+    setMotorOutput(0);
+}
+
+constexpr const char *FlywheelSubsystem::getMotorName(tap::motor::MotorId motorId)
+{
+#   define CASE_DJI_MOTOR_NUMBER(number) \
+    case tap::motor::MOTOR##number:      \
+        return "flywheel motor: " #number;
+
+    switch (motorId)
+    {
+    CASE_DJI_MOTOR_NUMBER(1);
+    CASE_DJI_MOTOR_NUMBER(2);
+    CASE_DJI_MOTOR_NUMBER(3);
+    CASE_DJI_MOTOR_NUMBER(4);
+    CASE_DJI_MOTOR_NUMBER(5);
+    CASE_DJI_MOTOR_NUMBER(6);
+    CASE_DJI_MOTOR_NUMBER(7);
+    CASE_DJI_MOTOR_NUMBER(8);
+    default:
+        return "flywheel motor: Unexpected MotorId";
+    }
+
+#   undef CASE_DJI_MOTOR_NUMBER
+}
+#endif
+
+void FlywheelSubsystem::initialize()
+{
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+    drivers->pwm.write(MIN_SNAIL_OUTPUT, motorPin);
+#else
+    motor.initialize();
+#endif
+}
+
+// void FlywheelSubsystem::refresh() {}
+
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+void FlywheelSubsystem::setMotorOutput(float normalizedOutput) const
+{
+    // Map [0.0f, 1.0f] to [MIN_SNAIL_OUTPUT, MAX_SNAIL_OUTPUT]
+    drivers->pwm.write(
+        MIN_SNAIL_OUTPUT + (MAX_SNAIL_OUTPUT - MIN_SNAIL_OUTPUT) * normalizedOutput,
+        motorPin
+    );
+}
+#else
+void FlywheelSubsystem::setMotorOutput(int desiredRPM)
+{
+    if (desiredRPM == 0)
+    {
+        motor.setDesiredOutput(0);
+    }
+    else
+    {
+        pidController.update(desiredRPM - motor.getShaftRPM());
+        motor.setDesiredOutput(static_cast<int32_t>(pidController.getValue()));
+    }
+}
+#endif
+
+}

--- a/ut-robomaster/src/subsystems/shooter/flywheel_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/flywheel_subsystem.hpp
@@ -1,0 +1,68 @@
+#ifndef SUBSYSTEMS_SHOOTER_FLYWHEEL_SUBSYSTEM_HPP_
+#define SUBSYSTEMS_SHOOTER_FLYWHEEL_SUBSYSTEM_HPP_
+
+// Remove to use DJI motors
+#define FLYWHEELS_USE_SNAIL_MOTORS
+
+#include "tap/control/subsystem.hpp"
+
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+#   include "tap/communication/gpio/pwm.hpp"
+#else
+#   include "modm/math/filter/pid.hpp"
+#   include "tap/communication/can/can.hpp"
+#   include "tap/motor/dji_motor.hpp"
+#endif
+
+
+namespace subsystems
+{
+namespace shooter
+{
+
+// Steve's flywheels use the Snail motor
+// Eventually, the new flywheels will use DJI motors
+class FlywheelSubsystem : public tap::control::Subsystem
+{
+public:
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+    FlywheelSubsystem(tap::Drivers *drivers, tap::gpio::Pwm::Pin motorPin);
+#else
+    FlywheelSubsystem(tap::Drivers *drivers, tap::motor::MotorId motorId, tap::can::CanBus canBusMotors);
+#endif
+
+    ~FlywheelSubsystem() = default;
+
+    void initialize() override;
+
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+    // normalizedOutput is between 0.0f and 1.0f
+    void setMotorOutput(float normalizedOutput) const;
+#else
+    void setMotorOutput(int desiredRPM);
+#endif
+
+    // Default refresh for Subsystem is no-op
+    // void refresh() override;
+
+private:
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+    const tap::gpio::Pwm::Pin motorPin;
+    static constexpr float MAX_SNAIL_OUTPUT = 0.50f;    // max pwm input value
+    static constexpr float MIN_SNAIL_OUTPUT = 0.25f;    // min pwn input value
+#else
+    const tap::motor::MotorId motorId;
+    const tap::can::CanBus canBusMotors;
+    uint16_t motorOutput; // Unused?
+    modm::Pid<float> pidController; // Should the PID controller use int instead? Check kp
+    tap::motor::DjiMotor motor;
+    static constexpr float MAX_CURRENT_OUTPUT = 8000.0f;
+
+    static constexpr const char *getMotorName(tap::motor::MotorId motorId);
+#endif
+};
+
+}
+}
+
+#endif // SUBSYSTEMS_SHOOTER_FLYWHEEL_SUBSYSTEM_HPP_

--- a/ut-robomaster/src/subsystems/shooter/shooter_on_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_on_command.cpp
@@ -12,8 +12,9 @@ namespace shooter
 void ShooterOnCommand::initialize() {}
 
 void ShooterOnCommand::execute() { 
-    shooter->setFlywheelOutput(0.5); 
-    shooter->setAgitatorOutput(1000);
+    shooter->setFlywheelOutput(0.5);
+    // shooter->setAgitatorOutput(1000);
+    shooter->rotateAgitatorToTarget();
 }
 
 void ShooterOnCommand::end(bool) { 

--- a/ut-robomaster/src/subsystems/shooter/shooter_on_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_on_command.cpp
@@ -1,27 +1,28 @@
 #include "shooter_on_command.hpp"
 
+#include "tap/communication/gpio/leds.hpp"
 #include "tap/control/command.hpp"
 
 #include "shooter_subsystem.hpp"
-
-#include "tap/communication/gpio/leds.hpp"
 namespace subsystems
 {
 namespace shooter
 {
 void ShooterOnCommand::initialize() {}
 
-void ShooterOnCommand::execute() { 
+void ShooterOnCommand::execute()
+{
     shooter->setFlywheelOutput(0.10);
-    // shooter->setAgitatorOutput(1000);
-    shooter->rotateAgitatorToTarget();
+    shooter->setAgitatorOutput(500);
+    // shooter->rotateAgitatorToTarget();
 }
 
-void ShooterOnCommand::end(bool) { 
-    shooter->setFlywheelOutput(0); 
+void ShooterOnCommand::end(bool)
+{
+    shooter->setFlywheelOutput(0);
     shooter->setAgitatorOutput(0);
 }
 
 bool ShooterOnCommand::isFinished() const { return false; }
 }  // namespace shooter
-}  // namespace control
+}  // namespace subsystems

--- a/ut-robomaster/src/subsystems/shooter/shooter_on_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_on_command.cpp
@@ -12,7 +12,7 @@ namespace shooter
 void ShooterOnCommand::initialize() {}
 
 void ShooterOnCommand::execute() { 
-    shooter->setFlywheelOutput(0.5);
+    shooter->setFlywheelOutput(0.10);
     // shooter->setAgitatorOutput(1000);
     shooter->rotateAgitatorToTarget();
 }

--- a/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
@@ -1,0 +1,24 @@
+#include "shooter_single_fire_command.hpp"
+
+#include "tap/control/command.hpp"
+
+#include "shooter_subsystem.hpp"
+
+#include "tap/communication/gpio/leds.hpp"
+namespace subsystems
+{
+namespace shooter
+{
+void ShooterSingleFireCommand::initialize() {}
+
+void ShooterSingleFireCommand::execute() { 
+    uint64_t incrementAmount = 2048;
+    shooter->incrementAgitatorTargetAngle(incrementAmount);
+}
+
+void ShooterSingleFireCommand::end(bool) { 
+}
+
+bool ShooterSingleFireCommand::isFinished() const { return false; }
+}  // namespace shooter
+}  // namespace control

--- a/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
@@ -12,8 +12,7 @@ namespace shooter
 void ShooterSingleFireCommand::initialize() {}
 
 void ShooterSingleFireCommand::execute() { 
-    uint64_t incrementAmount = 2048;
-    shooter->incrementAgitatorTargetAngle(incrementAmount);
+    shooter->shootBalls(3);
 }
 
 void ShooterSingleFireCommand::end(bool) { 

--- a/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
@@ -12,7 +12,7 @@ namespace shooter
 void ShooterSingleFireCommand::initialize() {}
 
 void ShooterSingleFireCommand::execute() { 
-    shooter->shootBalls(3);
+    shooter->shootBalls(2);
 }
 
 void ShooterSingleFireCommand::end(bool) { 

--- a/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.cpp
@@ -1,23 +1,27 @@
 #include "shooter_single_fire_command.hpp"
 
+#include "tap/communication/gpio/leds.hpp"
 #include "tap/control/command.hpp"
+
+#include "robots/standard/robot_comms.hpp"
 
 #include "shooter_subsystem.hpp"
 
-#include "tap/communication/gpio/leds.hpp"
 namespace subsystems
 {
 namespace shooter
 {
 void ShooterSingleFireCommand::initialize() {}
 
-void ShooterSingleFireCommand::execute() { 
+void ShooterSingleFireCommand::execute()
+{
+    comms::RobotCommsSingleton::print("ShooterSingleFireCommand::execute()");
+
     shooter->shootBalls(2);
 }
 
-void ShooterSingleFireCommand::end(bool) { 
-}
+void ShooterSingleFireCommand::end(bool) {}
 
 bool ShooterSingleFireCommand::isFinished() const { return false; }
 }  // namespace shooter
-}  // namespace control
+}  // namespace subsystems

--- a/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_single_fire_command.hpp
@@ -1,0 +1,38 @@
+#ifndef SHOOTER_SINGLE_FIRE_COMMAND_HPP_
+#define SHOOTER_SINGLE_FIRE_COMMAND_HPP_
+
+#include "tap/control/command.hpp"
+
+#include "shooter_subsystem.hpp"
+
+namespace subsystems
+{
+namespace shooter
+{
+class ShooterSingleFireCommand : public tap::control::Command
+{
+public:
+    ShooterSingleFireCommand(ShooterSubsystem *sub)
+        : shooter(sub)
+    {
+        addSubsystemRequirement(sub);
+    }
+
+    void initialize() override;
+
+    void execute() override;
+
+    void end(bool interrupted) override;
+
+    bool isFinished() const override;
+
+    const char *getName() const override { return "shooter single fire command"; }
+
+private:
+    ShooterSubsystem *shooter;
+
+};  // class ShooterOnCommand
+}  // namespace shooter
+}  // namespace control
+
+#endif  // SHOOTER_SINGLE_FIRE_COMMAND_HPP_

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -1,7 +1,7 @@
 #include "shooter_subsystem.hpp"
 #include "tap/communication/gpio/leds.hpp"
 #include "tap/communication/serial/remote.hpp"
-
+#include "robots/standard/robot_comms.hpp"
 using namespace tap;
 using namespace tap::gpio;
 
@@ -66,6 +66,8 @@ void ShooterSubsystem::rotateAgitatorToTarget()
     test.set(Leds::LedPin::Green, (valueToDisplay % 3) == 0);
     test.set(Leds::LedPin::Red, (valueToDisplay % 3) == 1);
     test.set(Leds::LedPin::Blue, (valueToDisplay % 3) == 2);
+
+    sprintf(comms::RobotCommsSingleton::getInstance().robotStream, "Balls to shoot: %d", valueToDisplay);
 }
 
 void ShooterSubsystem::shootBalls(int numBalls)

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -54,7 +54,7 @@ void ShooterSubsystem::setAgitatorOutput(int desiredRPM)
 
 void ShooterSubsystem::rotateAgitatorToTarget()
 {
-    if (agitator.isNearTarget(targetAngle) && ballsToShoot > 0)
+    if (!agitator.isNearTarget(targetAngle) && ballsToShoot > 0)
     {
         targetAngle += AGITATOR_INCREMENT_AMOUNT;
         ballsToShoot--;

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -54,22 +54,25 @@ void ShooterSubsystem::setAgitatorOutput(int desiredRPM)
 
 void ShooterSubsystem::rotateAgitatorToTarget()
 {
-    if (!agitator.isNearTarget(targetAngle) && ballsToShoot > 0)
+    if (agitator.isNearTarget(targetAngle) && ballsToShoot > 0)
     {
         targetAngle += AGITATOR_INCREMENT_AMOUNT;
         ballsToShoot--;
     }
     agitator.rotateToTarget(targetAngle);
 
+    int valueToDisplay = ballsToShoot;
     // for fun    
-    test.set(Leds::LedPin::Green, (targetAngle % 3) == 0);
-    test.set(Leds::LedPin::Red, (targetAngle % 3) == 1);
-    test.set(Leds::LedPin::Blue, (targetAngle % 3) == 2);
+    test.set(Leds::LedPin::Green, (valueToDisplay % 3) == 0);
+    test.set(Leds::LedPin::Red, (valueToDisplay % 3) == 1);
+    test.set(Leds::LedPin::Blue, (valueToDisplay % 3) == 2);
 }
 
 void ShooterSubsystem::shootBalls(int numBalls)
 {
     ballsToShoot += numBalls;
+    // targetAngle += AGITATOR_INCREMENT_AMOUNT;
+    // ballsToShoot--;
 }
 
 

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -1,6 +1,8 @@
 #include "shooter_subsystem.hpp"
+
 #include "tap/communication/gpio/leds.hpp"
 #include "tap/communication/serial/remote.hpp"
+
 #include "robots/standard/robot_comms.hpp"
 using namespace tap;
 using namespace tap::gpio;
@@ -11,46 +13,42 @@ namespace subsystems
 {
 namespace shooter
 {
-    
-ShooterSubsystem::ShooterSubsystem(tap::Drivers *drivers)
-    :   tap::control::Subsystem(drivers),
+
+ShooterSubsystem::ShooterSubsystem(tap::Drivers* drivers)
+    : tap::control::Subsystem(drivers),
 #ifdef FLYWHEELS_USE_SNAIL_MOTORS
-        flywheel(drivers, FLYWHEEL_MOTOR_PIN),
+      flywheel(drivers, FLYWHEEL_MOTOR_PIN),
 #else
-        flywheel(drivers, FLYWHEEL_MOTOR_ID, CAN_BUS_MOTORS),
+      flywheel(drivers, FLYWHEEL_MOTOR_ID, CAN_BUS_MOTORS),
 #endif
-        agitator(drivers, AGITATOR_MOTOR_ID, CAN_BUS_MOTORS),
-        targetAngle(0)
-{}
+      agitator(drivers, AGITATOR_MOTOR_ID, CAN_BUS_MOTORS),
+      targetAngle(0)
+{
+}
 
 void ShooterSubsystem::registerSubsystems()
 {
     drivers->commandScheduler.registerSubsystem(&flywheel);
     drivers->commandScheduler.registerSubsystem(&agitator);
 }
-        
-void ShooterSubsystem::initialize() { 
+
+void ShooterSubsystem::initialize()
+{
     flywheel.initialize();
     agitator.initialize();
     test.init();
 }
 
 #ifdef FLYWHEELS_USE_SNAIL_MOTORS
-void ShooterSubsystem::setFlywheelOutput(double normalizedOutput) // between 0 and 1
+void ShooterSubsystem::setFlywheelOutput(double normalizedOutput)  // between 0 and 1
 {
     flywheel.setMotorOutput(normalizedOutput);
 }
 #else
-void ShooterSubsystem::setFlywheelOutput(int desiredRPM)
-{
-    flywheel.setMotorOutput(desiredRPM);
-}
+void ShooterSubsystem::setFlywheelOutput(int desiredRPM) { flywheel.setMotorOutput(desiredRPM); }
 #endif
 
-void ShooterSubsystem::setAgitatorOutput(int desiredRPM)
-{
-    agitator.setMotorOutput(desiredRPM);
-}
+void ShooterSubsystem::setAgitatorOutput(int desiredRPM) { agitator.setMotorOutput(desiredRPM); }
 
 void ShooterSubsystem::rotateAgitatorToTarget()
 {
@@ -62,23 +60,32 @@ void ShooterSubsystem::rotateAgitatorToTarget()
     agitator.rotateToTarget(targetAngle);
 
     int valueToDisplay = ballsToShoot;
-    // for fun    
+    // for fun
     test.set(Leds::LedPin::Green, (valueToDisplay % 3) == 0);
     test.set(Leds::LedPin::Red, (valueToDisplay % 3) == 1);
     test.set(Leds::LedPin::Blue, (valueToDisplay % 3) == 2);
 
-    sprintf(comms::RobotCommsSingleton::getInstance().robotStream, "Balls to shoot: %d", valueToDisplay);
+    comms::RobotCommsSingleton::print("Balls to shoot: %d", valueToDisplay);
 }
 
 void ShooterSubsystem::shootBalls(int numBalls)
 {
+    const char* toPrint = "SHOOTING BALLS; BEFORE COMMAND: ballsToShoot = %d, numBalls = %d";
+
+    comms::RobotCommsSingleton::print(toPrint, ballsToShoot, numBalls);
+
     ballsToShoot += numBalls;
+
+    const char* newPrint = "AFTER ballsToShoot = %d, numBalls = %d";
+
+    // add new balls to shoot to toPrint
+    comms::RobotCommsSingleton::print(newPrint, ballsToShoot, numBalls);
+
     // targetAngle += AGITATOR_INCREMENT_AMOUNT;
     // ballsToShoot--;
 }
 
-
 void ShooterSubsystem::refresh() {}
 
-}
-}
+}  // namespace shooter
+}  // namespace subsystems

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -54,18 +54,22 @@ void ShooterSubsystem::setAgitatorOutput(int desiredRPM)
 
 void ShooterSubsystem::rotateAgitatorToTarget()
 {
-    int x = targetAngle;
-    test.set(Leds::LedPin::Green, (x % 3) == 0);
-    test.set(Leds::LedPin::Red, (x % 3) == 1);
-    test.set(Leds::LedPin::Blue, (x % 3) == 2);
+    if (agitator.isNearTarget(targetAngle) && ballsToShoot > 0)
+    {
+        targetAngle += AGITATOR_INCREMENT_AMOUNT;
+        ballsToShoot--;
+    }
     agitator.rotateToTarget(targetAngle);
+
+    // for fun    
+    test.set(Leds::LedPin::Green, (targetAngle % 3) == 0);
+    test.set(Leds::LedPin::Red, (targetAngle % 3) == 1);
+    test.set(Leds::LedPin::Blue, (targetAngle % 3) == 2);
 }
 
-void ShooterSubsystem::incrementAgitatorTargetAngle(uint64_t increment)
+void ShooterSubsystem::shootBalls(int numBalls)
 {
-    targetAngle = targetAngle + 2820;
-    //rotateAgitatorToTarget();
-    
+    ballsToShoot += numBalls;
 }
 
 

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -63,7 +63,7 @@ void ShooterSubsystem::rotateAgitatorToTarget()
 
 void ShooterSubsystem::incrementAgitatorTargetAngle(uint64_t increment)
 {
-    targetAngle = targetAngle + 2800;
+    targetAngle = targetAngle + 2820;
     //rotateAgitatorToTarget();
     
 }

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.cpp
@@ -1,8 +1,11 @@
 #include "shooter_subsystem.hpp"
-
+#include "tap/communication/gpio/leds.hpp"
 #include "tap/communication/serial/remote.hpp"
 
 using namespace tap;
+using namespace tap::gpio;
+
+tap::gpio::Leds test;
 
 namespace subsystems
 {
@@ -16,7 +19,8 @@ ShooterSubsystem::ShooterSubsystem(tap::Drivers *drivers)
 #else
         flywheel(drivers, FLYWHEEL_MOTOR_ID, CAN_BUS_MOTORS),
 #endif
-        agitator(drivers, AGITATOR_MOTOR_ID, CAN_BUS_MOTORS)
+        agitator(drivers, AGITATOR_MOTOR_ID, CAN_BUS_MOTORS),
+        targetAngle(0)
 {}
 
 void ShooterSubsystem::registerSubsystems()
@@ -28,6 +32,7 @@ void ShooterSubsystem::registerSubsystems()
 void ShooterSubsystem::initialize() { 
     flywheel.initialize();
     agitator.initialize();
+    test.init();
 }
 
 #ifdef FLYWHEELS_USE_SNAIL_MOTORS
@@ -46,6 +51,23 @@ void ShooterSubsystem::setAgitatorOutput(int desiredRPM)
 {
     agitator.setMotorOutput(desiredRPM);
 }
+
+void ShooterSubsystem::rotateAgitatorToTarget()
+{
+    int x = targetAngle;
+    test.set(Leds::LedPin::Green, (x % 3) == 0);
+    test.set(Leds::LedPin::Red, (x % 3) == 1);
+    test.set(Leds::LedPin::Blue, (x % 3) == 2);
+    agitator.rotateToTarget(targetAngle);
+}
+
+void ShooterSubsystem::incrementAgitatorTargetAngle(uint64_t increment)
+{
+    targetAngle = targetAngle + 2800;
+    //rotateAgitatorToTarget();
+    
+}
+
 
 void ShooterSubsystem::refresh() {}
 

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
@@ -53,7 +53,7 @@ private:
     static constexpr tap::motor::MotorId FLYWHEEL_MOTOR_ID = tap::motor::MOTOR1;
 #endif
 
-    static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR1;
+    static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR5;
     static constexpr u_int64_t AGITATOR_INCREMENT_AMOUNT = 2820; // TODO: FIGURE OUT WHY THIS IS 2820
     FlywheelSubsystem flywheel;
     AgitatorSubsystem agitator;

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
@@ -36,7 +36,8 @@ public:
     void setFlywheelOutput(int desiredRPM);
 #endif
     void setAgitatorOutput(int desiredRPM);
-
+    void rotateAgitatorToTarget();
+    void incrementAgitatorTargetAngle(u_int64_t increment);
     // Subsystem is no-op, unnecessary override?
     void refresh() override;
 
@@ -52,10 +53,11 @@ private:
     static constexpr tap::motor::MotorId FLYWHEEL_MOTOR_ID = tap::motor::MOTOR1;
 #endif
 
-    static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR1;
+    static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR5;
 
     FlywheelSubsystem flywheel;
     AgitatorSubsystem agitator;
+    uint64_t targetAngle;
 };
 
 }

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
@@ -1,6 +1,9 @@
 #ifndef SHOOTER_SUBSYSTEM_HPP_
 #define SHOOTER_SUBSYSTEM_HPP_
 
+#include "agitator_subsystem.hpp"
+#include "flywheel_subsystem.hpp"
+
 #include "tap/drivers.hpp"
 #include "tap/control/subsystem.hpp"
 #include "tap/communication/gpio/pwm.hpp"
@@ -11,6 +14,7 @@ namespace subsystems
 namespace shooter
 {
 
+// Manages Flywheel and Agitator subsystems
 class ShooterSubsystem : public tap::control::Subsystem
 {
 public:
@@ -20,35 +24,38 @@ public:
 
     ~ShooterSubsystem() = default;
 
+    // Registers the Flywheel and Agitator subsystems
+    void registerSubsystems();
+
     void initialize() override;
 
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
+    // Float or double?
     void setFlywheelOutput(double normalizedOutput);
+#else
+    void setFlywheelOutput(int desiredRPM);
+#endif
     void setAgitatorOutput(int desiredRPM);
 
+    // Subsystem is no-op, unnecessary override?
     void refresh() override;
 
+    // Unused?
     void checkRegistered();
 
 private:
-    // static constexpr tap::motor::MotorId FLYWHEEL_MOTOR_ID = tap::motor::MOTOR1;
-    // static constexpr tap::can::CanBus CAN_BUS_MOTORS = tap::can::CanBus::CAN_BUS1;
-    // uint16_t flywheelMotorOutput;
-    // modm::Pid<float> flywheelPidController;
-    // tap::motor::DjiMotor flywheelMotor;
+    static constexpr tap::can::CanBus CAN_BUS_MOTORS = tap::can::CanBus::CAN_BUS1;
 
-
+#ifdef FLYWHEELS_USE_SNAIL_MOTORS
     static constexpr tap::gpio::Pwm::Pin FLYWHEEL_MOTOR_PIN = tap::gpio::Pwm::C1;
-    static constexpr float MAX_SNAIL_OUTPUT = 0.50f;    // max pwm input value
-    static constexpr float MIN_SNAIL_OUTPUT = 0.25f;    // min pwm input value
+#else
+    static constexpr tap::motor::MotorId FLYWHEEL_MOTOR_ID = tap::motor::MOTOR1;
+#endif
 
     static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR1;
-    static constexpr tap::can::CanBus CAN_BUS_MOTORS = tap::can::CanBus::CAN_BUS1;
-    uint16_t agitatorMotorOutput;
-    modm::Pid<float> agitatorPidController;
-    tap::motor::DjiMotor agitatorMotor;
 
-    
-    tap::Drivers *drivers;
+    FlywheelSubsystem flywheel;
+    AgitatorSubsystem agitator;
 };
 
 }

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
@@ -53,7 +53,7 @@ private:
     static constexpr tap::motor::MotorId FLYWHEEL_MOTOR_ID = tap::motor::MOTOR1;
 #endif
 
-    static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR5;
+    static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR1;
     static constexpr u_int64_t AGITATOR_INCREMENT_AMOUNT = 2820; // TODO: FIGURE OUT WHY THIS IS 2820
     FlywheelSubsystem flywheel;
     AgitatorSubsystem agitator;

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
@@ -57,6 +57,7 @@ private:
     static constexpr u_int64_t AGITATOR_INCREMENT_AMOUNT = 2820; // TODO: FIGURE OUT WHY THIS IS 2820
     FlywheelSubsystem flywheel;
     AgitatorSubsystem agitator;
+    
     uint64_t targetAngle; // angle that the agitator should rotate to
     int ballsToShoot; // "queue" of balls to shoot
 };

--- a/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
+++ b/ut-robomaster/src/subsystems/shooter/shooter_subsystem.hpp
@@ -37,7 +37,7 @@ public:
 #endif
     void setAgitatorOutput(int desiredRPM);
     void rotateAgitatorToTarget();
-    void incrementAgitatorTargetAngle(u_int64_t increment);
+    void shootBalls(int numBalls);
     // Subsystem is no-op, unnecessary override?
     void refresh() override;
 
@@ -54,10 +54,11 @@ private:
 #endif
 
     static constexpr tap::motor::MotorId AGITATOR_MOTOR_ID = tap::motor::MOTOR5;
-
+    static constexpr u_int64_t AGITATOR_INCREMENT_AMOUNT = 2820; // TODO: FIGURE OUT WHY THIS IS 2820
     FlywheelSubsystem flywheel;
     AgitatorSubsystem agitator;
-    uint64_t targetAngle;
+    uint64_t targetAngle; // angle that the agitator should rotate to
+    int ballsToShoot; // "queue" of balls to shoot
 };
 
 }


### PR DESCRIPTION
Branch [feature/shooter-composition](https://github.com/ut-ras/robomaster/tree/feature/shooter-composition) attempts to abstract the flywheel and agitator modules away from the shooter subsystem. I believe that it will be easier to manage both modules separately from each other.

In short, the flywheel and agitator modules will become child subsystems that the shooter subsystem manages.